### PR TITLE
Feature/2 add cloudfront https

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,5 +58,5 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
           
       - name: Deploy to S3
-        run: aws s3 sync public/ s3://www.${{ secrets.AWS_REGISTERED_DOMAIN }} --delete
+        run: aws s3 sync public/ s3://${{ secrets.WEBSITE_DOMAIN_NAME }} --delete
 

--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # Infrastructure as Code (IaC) for Static Website Hosting on AWS S3
-## Demo: http://otaviocoding.click
-This project provisions a static website hosting with public read permitions infrastructure on AWS S3 using Terraform. It also includes a GitHub Actions workflow for continuous integration (CI), so every time you push to this repository, the changes are tested and the `public/` folder content is automatically deployed to the bucket. 
+## Demo: http://dev.otaviocoding.click
+This project provisions a static website hosting infrastructure with public read permitions on AWS S3 using Terraform. It also includes a GitHub Actions workflow for continuous integration (CI), so every time you push to this repository, the changes are tested and the `public/` folder content is automatically deployed to the bucket. 
 
 ## Dependencies
 
@@ -9,9 +9,13 @@ This project provisions a static website hosting with public read permitions inf
 ## Prerequisites
 
 ### For AWS Infrastructure
-
-- A registered domain with an existing hosted zone in Route 53  
-- Terraform installed and configured with valid AWS credentials
+- Valid AWS credentials
+- A registered domain `example.com` with an existing hosted zone in Route 53  
+- An ACM-Amazon Certificate Manager issued certificate for the domain name `*.example.com`. 
+- Your Route 53 Hosted Zone must contain:
+  - The certificate CNAME record.
+  - NS-Name Server record and a SOA-Stat of Authority record (if you bought your domain from Route 53 domain 
+  registry services the hosted zone will be created automatically with both).
 
 ### For GitHub Actions CI
 
@@ -21,28 +25,34 @@ This project provisions a static website hosting with public read permitions inf
   - `AWS_REGISTERED_DOMAIN`  
   These variables are required in the `deploy.yaml` workflow file.
 
-## AWS Resources Created
+## AWS Resources Created after `terraform apply`
 
-- **Two S3 Buckets**:
-  - One for the root domain (e.g., `example.com`) that redirects to the second bucket
-  - One for the `www` subdomain (e.g., `www.example.com`) which hosts the website content
+- **An S3 Bucket**:
+  - A bucket for the `www` subdomain (e.g., `www.example.com`) which stores the website content
+
+- **A CloudFront distribution**:
+  - A cloudfront distribution that will serve the `index.html` from the s3 bucket using a HTTPS connection.
 
 - **Route 53 Records**:
-  - Alias records pointing to the S3 buckets, created in an existing hosted zone
+  - Alias records pointing from `subdomain.example.com` to the CloudFront distribution, created in an existing hosted zone. 
 
 - **IAM Role**:
   - Configured with OIDC and can be assumed by GitHub Actions for secure, short-lived access
 
 ## How to use it 
 
-1. Set the terraform variable on a `.tfvars` file or pass it as arguments in the next step.
+1. Set the terraform variable on a `infra/.tfvars` file:
+```
+registered_domain = "example.com"
+acm_domain_name   = "*.example.com"
+subdomain         = "dev"
+aws_account_id    = <your-aws-account-id>
+github_account_id = "<your-github-id>"
+github_repo       = "<github-repo-name>" 
+```
 2. Run `terraform apply`. This step is necessary to create the IAM role and permissions that allow GitHub Actions to deploy to your S3 bucket.
 3. Update the `index.html` file and push your changes to main to trigger the CI. The contents of the `public/` folder will be deployed into your S3 bucket.
 4. That's it, your static website is up and running on your registered domain (`www.example.com` or `example.com`)
-
-## Disclaimer
-
-This infrastructure currently supports only **HTTP** connections. **Do not use this setup to host sensitive or private data.**
 
 ## Reference Documentation
 

--- a/infra/aws_acm.tf
+++ b/infra/aws_acm.tf
@@ -1,0 +1,8 @@
+/*
+  This file contains resources related to the TSL/SSL certificate.
+*/
+
+
+data "aws_acm_certificate" "issued" {
+  domain = var.acm_domain_name
+}

--- a/infra/aws_cloudfront.tf
+++ b/infra/aws_cloudfront.tf
@@ -1,0 +1,42 @@
+/*
+  This file contains resources related to the CloudFront distribution of our site.
+*/
+
+data "aws_cloudfront_cache_policy" "cache_policy" {
+  name = "Managed-CachingOptimized"
+}
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  origin {
+    domain_name = aws_s3_bucket.subdomain.bucket_regional_domain_name
+    origin_id   = aws_s3_bucket.subdomain.id
+  }
+
+  enabled             = true
+  comment             = "Awesome CloudFront distribution"
+  default_root_object = "index.html"
+
+  aliases = ["${var.subdomain}.${var.registered_domain}"]
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = aws_s3_bucket.subdomain.id
+    cache_policy_id        = data.aws_cloudfront_cache_policy.cache_policy.id
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn = data.aws_acm_certificate.issued.arn
+    ssl_support_method  = "sni-only"
+  }
+}

--- a/infra/aws_route53.tf
+++ b/infra/aws_route53.tf
@@ -1,45 +1,26 @@
 /*
   This file defines the infrastructure to create Route 53 alias records 
-  for both the root domain (example.com) and the www subdomain (www.example.com),
-  pointing them to their respective S3 static website hosting buckets.
-
-  Prerequisites:
-  - The domain must be registered.
-  - A corresponding Route 53 hosted zone must already exist.
+  for both the root domain (example.com) routing it to the CloudFront distribution.
 */
 
 data "aws_route53_zone" "hosted_zone" {
-  name = var.registered_domain
+  name = var.registered_domain # hosted zone name is the same as your registered domain
 }
 
-data "aws_s3_bucket" "www" {
-  bucket = aws_s3_bucket.www.bucket
+data "aws_s3_bucket" "subdomain" {
+  bucket = aws_s3_bucket.subdomain.bucket
 }
 
-resource "aws_route53_record" "www" {
+resource "aws_route53_record" "subdomain" {
   zone_id = data.aws_route53_zone.hosted_zone.zone_id
-  name    = "www.${var.registered_domain}"
+  name    = "${var.subdomain}.${var.registered_domain}"
   type    = "A"
-  
+
   alias {
-    name = data.aws_s3_bucket.www.website_domain
-    zone_id = data.aws_s3_bucket.www.hosted_zone_id
+    name                   = aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.s3_distribution.hosted_zone_id
     evaluate_target_health = false
   }
-}
 
-data "aws_s3_bucket" "root" {
-  bucket = aws_s3_bucket.root.bucket
-}
-
-resource "aws_route53_record" "root" {
-  zone_id = data.aws_route53_zone.hosted_zone.zone_id
-  name    = var.registered_domain
-  type    = "A"
-  
-  alias {
-    name = data.aws_s3_bucket.root.website_domain
-    zone_id = data.aws_s3_bucket.root.hosted_zone_id
-    evaluate_target_health = false
-  }
+  depends_on = [aws_cloudfront_distribution.s3_distribution]
 }

--- a/infra/github_actions.tf
+++ b/infra/github_actions.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "s3_deploy_policy" {
   statement {
     effect    = "Allow"
     actions   = ["s3:PutObject", "s3:DeleteObject", "s3:ListBucket"]
-    resources = ["arn:aws:s3:::${aws_s3_bucket.www.id}/*"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.subdomain.id}/*"]
   }
 }
 resource "aws_iam_role_policy" "s3_deploy_policy" {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -3,6 +3,16 @@ variable "registered_domain" {
   type        = string
 }
 
+variable "subdomain" {
+  description = "Desired subdomain (default value is www)."
+  type        = string
+  default     = "www"
+}
+
+variable "acm_domain_name" {
+  description = "The main domain name of the AWS Certificate Manager issued certificate (example.com or *.example.com)"
+  type        = string
+}
 variable "aws_account_id" {
   description = "AWS account ID"
   type        = number


### PR DESCRIPTION
Closes #2 

feat(infra): Add CloudFront Distribution to allow HTTPS connection

Additions include:
- Resource block for CloudFront creation.
- Data block to retrieve the TCL/SSL certification data.

Changes include:
- Now, we are not creating two buckets like before (example.com and subdomain.example.com)
Instead, we are using just the 'subdomain.example.com' and the content will be only accessible
via 'subdomain.example.com'.
- The s3 buckets had static hosting disabled because now we're using CloudFront to serve
the content
- Changed resources name from 'www' to 'subdomain' and added a subdomain variable.


Risks:
Hosted Zones and SSL certificate still have to be setup manually for everything to work increasing error odds.
